### PR TITLE
Feat/create collective

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,9 +39,8 @@ import Rewards from "./pages/Rewards";
 import { useSignInWallet } from "./hooks/useSignInWallet";
 import { isPlatform } from "@ionic/react";
 import OnboardingModal from "./components/OnboardingModal";
-import Mint from "./pages/Mint/Mint";
 import Challenges from "./pages/Mint/Challenges";
-import Group from "./pages/Mint/Group";
+import Mint from "./pages/Mint/Mint";
 
 setupIonicReact({
   mode: "ios",
@@ -86,7 +85,6 @@ const App: React.FC = () => {
       <Route path="/rewards" render={() => <Rewards />} exact />
 
       <Route path="/mint" component={Mint} />
-      <Route path="/mint/:groupId" component={Group} />
       <Route path="/challenges" render={() => <Challenges />} exact />
       <Route path="/challenge/:id" render={() => <Challenge />} exact />
 

--- a/frontend/src/components/Mint/MintTopBar.tsx
+++ b/frontend/src/components/Mint/MintTopBar.tsx
@@ -1,0 +1,20 @@
+import PageTopBar from "@/components/PageTopBar";
+import { routes } from "@/utils/routeNames";
+import { RouteComponentProps } from "react-router";
+export interface DiscoverTopBarProps {
+  children?: React.ReactNode;
+}
+const MintTopBar: React.FC<DiscoverTopBarProps> = ({ children }) => {
+  return (
+    <PageTopBar
+      tabs={[
+        { label: "Collectives", href: routes.mintPage.myCollectives },
+        { label: "Invites", href: routes.mintPage.collectiveInvites },
+      ]}
+    >
+      {children}
+    </PageTopBar>
+  );
+};
+
+export default MintTopBar;

--- a/frontend/src/hooks/Groups/useGetMyGroups.ts
+++ b/frontend/src/hooks/Groups/useGetMyGroups.ts
@@ -13,25 +13,31 @@ export function useGetMyGroups() {
         setMyGroups(null);
     }
 
-    useEffect(() => {
-        const fetchGroups = async () => {
+    const fetchUserGroups = async () => {
+        setLoading(true)
+        try {
+            if (address && !myGroups) {
+                const _myGroups: Group[] = await ApiService.readGroupByMemberAddress(address)
+                setMyGroups(_myGroups)
+            } else if (!address) {
+                setMyGroups(null)
 
-            try {
-                if (address && !myGroups) {
-                    setLoading(true)
-                    const _myGroups: Group[] = await ApiService.readGroupByMemberAddress(address)
-                    setMyGroups(_myGroups)
-                    setLoading(false)
-
-                }
-            } catch (error) {
-                console.log(error, 'Error fetching my groups')
             }
+        } catch (error) {
+            console.log(error, 'Error fetching my groups')
+        }
+        setLoading(false)
+    };
 
-        };
-        fetchGroups();
-    }, [myGroups]);
-    return { myGroups, loading, reload };
+
+    useEffect(() => {
+        // Fetch groups on component mount and whenever the address changes
+        fetchUserGroups();
+    }, [address, myGroups]);
+
+
+    return { myGroups, loading, reload, fetchUserGroups };
+
 }
 
 export default useGetMyGroups;

--- a/frontend/src/pages/Mint/CollectiveInvites.tsx
+++ b/frontend/src/pages/Mint/CollectiveInvites.tsx
@@ -1,25 +1,19 @@
 import { IonContent, IonPage } from "@ionic/react";
-import { PageLoadingIndicator } from "@/components/PageLoadingIndicator";
 import Header from "@/components/Header";
 import { RouteComponentProps } from "react-router";
 import MintTopBar from "@/components/Mint/MintTopBar";
 
-export interface ManageCollectiveProps {
-  group?: any;
-  loading: boolean;
-}
-
-const ManageCollective: React.FC<RouteComponentProps> = ({ match }) => {
+const CollectiveInvites: React.FC<RouteComponentProps> = ({ match }) => {
   return (
     <IonPage>
       <Header title="Manage Collective" />
 
       <IonContent className="ion-padding" color="light">
         <MintTopBar />
-        <p>Manage Collective/group settings page here</p>
+        <p>Put all the users current collective invites here</p>
       </IonContent>
     </IonPage>
   );
 };
 
-export default ManageCollective;
+export default CollectiveInvites;

--- a/frontend/src/pages/Mint/CreateCollective.tsx
+++ b/frontend/src/pages/Mint/CreateCollective.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import {
+  IonItem,
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonList,
+  IonModal,
+  IonTitle,
+  IonToolbar,
+  IonInput,
+  IonTextarea,
+  IonLabel,
+  IonListHeader,
+  IonSelect,
+  IonSelectOption,
+  IonFooter,
+} from "@ionic/react";
+import ApiService from "@/services/ApiService";
+import { GroupCreation } from "@/types/chat";
+import { useAccount } from "wagmi";
+import { RouteComponentProps, useHistory } from "react-router";
+
+export interface CreateCollectiveProps {
+  presentingElement?: HTMLElement;
+  dismiss?: () => void;
+  onSuccess?: (groupId: number) => void;
+  trigger: string;
+}
+//TODO: Make this a page, not a modal
+const CreateCollective: React.FC<RouteComponentProps> = ({ match }) => {
+  const [groupName, setGroupName] = useState("");
+  const [groupId, setGroupId] = useState<number | null>(null);
+  const { address } = useAccount();
+  const history = useHistory();
+
+  const cancel = () => {
+    history.goBack();
+  };
+
+  const handleCreateGroup = async () => {
+    const groupObject: GroupCreation = {
+      name: groupName,
+      publicAddress: "0x0232u326483848787ndas7298bda7289da", //TODO: hardcoded for now but will have to create the contract address from our factory
+    };
+    try {
+      const result = await ApiService.createGroup(groupObject);
+      setGroupId(result.id);
+      //onSuccess(result.id);
+    } catch (error) {
+      console.log(error, "error posting group");
+    }
+  };
+
+  return (
+    <IonContent>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Create New Group</IonTitle>
+          <IonButtons slot="start" className="ion-hide-md-up">
+            <IonButton color="secondary" onClick={cancel}>
+              Cancel
+            </IonButton>
+          </IonButtons>
+          <IonButtons slot="end" className="ion-hide-md-up">
+            <IonButton onClick={handleCreateGroup}>Create</IonButton>
+          </IonButtons>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent color="light">
+        <IonList className="ion-padding" inset={true}>
+          <IonItem>
+            <IonInput
+              label="Name"
+              label-placement="floating"
+              placeholder="Enter the name"
+              onIonInput={(e) => setGroupName(e.detail.value!)}
+            ></IonInput>
+          </IonItem>
+          <IonItem>
+            <IonTextarea
+              label="Description"
+              label-placement="floating"
+              placeholder="Enter the description"
+            ></IonTextarea>
+          </IonItem>
+        </IonList>
+
+        <IonList className="ion-padding" inset={true}>
+          <IonListHeader>
+            <IonLabel>First Pool</IonLabel>
+          </IonListHeader>
+          <IonItem>
+            <IonInput
+              label="Chain Id"
+              label-placement="floating"
+              placeholder="Enter the chain id"
+            ></IonInput>
+          </IonItem>
+          <IonItem>
+            <IonInput
+              label="Platform Url"
+              label-placement="floating"
+              placeholder="Enter the Platform Url"
+            ></IonInput>
+          </IonItem>
+          <IonItem>
+            <IonInput
+              label="Token Id"
+              label-placement="floating"
+              placeholder="Enter the Token Id"
+            ></IonInput>
+          </IonItem>
+          <IonItem>
+            <IonInput
+              label="Minting Contract Address"
+              label-placement="floating"
+              placeholder="Enter the Minting Contract Address"
+            ></IonInput>
+          </IonItem>
+          <IonItem>
+            <IonSelect label="Type of Pool" placeholder="Type of Pool">
+              <IonSelectOption value="type1">Type 1</IonSelectOption>
+              <IonSelectOption value="type2">Type 2</IonSelectOption>
+              <IonSelectOption value="type3">Type 3</IonSelectOption>
+            </IonSelect>
+          </IonItem>
+          <IonItem>
+            <IonInput
+              label="Length (Days)"
+              type="number"
+              placeholder="Length (Days)"
+            ></IonInput>
+          </IonItem>
+          <IonItem>
+            <IonTextarea
+              label="Terms"
+              label-placement="floating"
+              placeholder="Enter the Terms"
+            ></IonTextarea>
+          </IonItem>
+        </IonList>
+      </IonContent>
+      <IonFooter className="ion-hide ion-show-md-up">
+        <IonToolbar>
+          <IonButtons slot="end">
+            <IonButton
+              className="footer-button"
+              onClick={cancel}
+              shape="round"
+              fill="outline"
+            >
+              Cancel
+            </IonButton>
+            <IonButton
+              className="footer-button"
+              onClick={handleCreateGroup}
+              shape="round"
+              fill="solid"
+            >
+              Create Group
+            </IonButton>
+          </IonButtons>
+        </IonToolbar>
+      </IonFooter>
+    </IonContent>
+  );
+};
+
+export default CreateCollective;

--- a/frontend/src/pages/Mint/CreateCollective.tsx
+++ b/frontend/src/pages/Mint/CreateCollective.tsx
@@ -16,11 +16,13 @@ import {
   IonSelect,
   IonSelectOption,
   IonFooter,
+  IonPage,
 } from "@ionic/react";
 import ApiService from "@/services/ApiService";
 import { GroupCreation } from "@/types/chat";
 import { useAccount } from "wagmi";
 import { RouteComponentProps, useHistory } from "react-router";
+import Header from "@/components/Header";
 
 export interface CreateCollectiveProps {
   presentingElement?: HTMLElement;
@@ -54,20 +56,9 @@ const CreateCollective: React.FC<RouteComponentProps> = ({ match }) => {
   };
 
   return (
-    <IonContent>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>Create New Group</IonTitle>
-          <IonButtons slot="start" className="ion-hide-md-up">
-            <IonButton color="secondary" onClick={cancel}>
-              Cancel
-            </IonButton>
-          </IonButtons>
-          <IonButtons slot="end" className="ion-hide-md-up">
-            <IonButton onClick={handleCreateGroup}>Create</IonButton>
-          </IonButtons>
-        </IonToolbar>
-      </IonHeader>
+    <IonPage>
+      <Header title="Create Collective" />
+
       <IonContent color="light">
         <IonList className="ion-padding" inset={true}>
           <IonItem>
@@ -142,29 +133,7 @@ const CreateCollective: React.FC<RouteComponentProps> = ({ match }) => {
           </IonItem>
         </IonList>
       </IonContent>
-      <IonFooter className="ion-hide ion-show-md-up">
-        <IonToolbar>
-          <IonButtons slot="end">
-            <IonButton
-              className="footer-button"
-              onClick={cancel}
-              shape="round"
-              fill="outline"
-            >
-              Cancel
-            </IonButton>
-            <IonButton
-              className="footer-button"
-              onClick={handleCreateGroup}
-              shape="round"
-              fill="solid"
-            >
-              Create Group
-            </IonButton>
-          </IonButtons>
-        </IonToolbar>
-      </IonFooter>
-    </IonContent>
+    </IonPage>
   );
 };
 

--- a/frontend/src/pages/Mint/Group.tsx
+++ b/frontend/src/pages/Mint/Group.tsx
@@ -25,10 +25,13 @@ const Mint: React.FC<RouteComponentProps> = ({ match }) => {
     <IonPage>
       <Header title={group?.name} />
       <IonContent className="ion-padding" color="light">
-      <IonToolbar>
-        <IonSearchbar showClearButton="focus" value="Show on Focus"></IonSearchbar>
-      </IonToolbar>
-      
+        <IonToolbar>
+          <IonSearchbar
+            showClearButton="focus"
+            value="Show on Focus"
+          ></IonSearchbar>
+        </IonToolbar>
+
         {loading ? (
           <PageLoadingIndicator />
         ) : (
@@ -36,7 +39,7 @@ const Mint: React.FC<RouteComponentProps> = ({ match }) => {
             <IonRouterOutlet>
               <Route
                 path={`/mint/:groupId/challenges`}
-                render={() => <Challenges/>}
+                render={() => <Challenges />}
                 exact
               />
               <Route
@@ -55,7 +58,7 @@ const Mint: React.FC<RouteComponentProps> = ({ match }) => {
                 render={() => <Info group={group} loading={loading} />}
               />
             </IonRouterOutlet>
-            <IonTabBar slot="top" style={{ marginTop: '100px' }}>
+            <IonTabBar slot="top" style={{ marginTop: "100px" }}>
               <IonTabButton tab="challenges" href={`${match.url}/challenges`}>
                 <IonLabel>Challenges</IonLabel>
               </IonTabButton>

--- a/frontend/src/pages/Mint/Group.tsx
+++ b/frontend/src/pages/Mint/Group.tsx
@@ -23,7 +23,7 @@ const Mint: React.FC<RouteComponentProps> = ({ match }) => {
   const { group, loading } = useGetGroupById(groupId);
   return (
     <IonPage>
-      <Header title={group?.name} />
+      {/*       <Header title={group?.name} />
       <IonContent className="ion-padding" color="light">
         <IonToolbar>
           <IonSearchbar
@@ -71,7 +71,7 @@ const Mint: React.FC<RouteComponentProps> = ({ match }) => {
             </IonTabBar>
           </IonTabs>
         )}
-      </IonContent>
+      </IonContent> */}
     </IonPage>
   );
 };

--- a/frontend/src/pages/Mint/ManageCollective.tsx
+++ b/frontend/src/pages/Mint/ManageCollective.tsx
@@ -1,14 +1,17 @@
 import { IonContent, IonPage } from "@ionic/react";
 import { PageLoadingIndicator } from "@/components/PageLoadingIndicator";
+import Header from "@/components/Header";
+import { RouteComponentProps } from "react-router";
 
 export interface ManageCollectiveProps {
   group?: any;
   loading: boolean;
 }
 
-const ManageCollective = ({ group, loading }: ManageCollectiveProps) => {
+const ManageCollective: React.FC<RouteComponentProps> = ({ match }) => {
   return (
     <IonPage>
+      <Header title="Manage Collective" />
       <IonContent className="ion-padding" color="light">
         <p>Manage Collective/group settings page here</p>
       </IonContent>

--- a/frontend/src/pages/Mint/ManageCollective.tsx
+++ b/frontend/src/pages/Mint/ManageCollective.tsx
@@ -1,0 +1,19 @@
+import { IonContent, IonPage } from "@ionic/react";
+import { PageLoadingIndicator } from "@/components/PageLoadingIndicator";
+
+export interface ManageCollectiveProps {
+  group?: any;
+  loading: boolean;
+}
+
+const ManageCollective = ({ group, loading }: ManageCollectiveProps) => {
+  return (
+    <IonPage>
+      <IonContent className="ion-padding" color="light">
+        <p>Manage Collective/group settings page here</p>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default ManageCollective;

--- a/frontend/src/pages/Mint/Mint.tsx
+++ b/frontend/src/pages/Mint/Mint.tsx
@@ -1,13 +1,16 @@
 import Header from "@/components/Header";
-import { IonButton, IonContent, IonPage } from "@ionic/react";
+import { IonButton, IonContent, IonPage, IonRouterOutlet } from "@ionic/react";
 import { useEffect, useRef, useState } from "react";
 import useGetMyGroups from "@/hooks/Groups/useGetMyGroups";
 import CreateGroupModal from "./CreateGroupModal";
 import { PageLoadingIndicator } from "@/components/PageLoadingIndicator";
-import { RouteComponentProps } from "react-router";
+import { Redirect, Route, RouteComponentProps } from "react-router";
 import { shortenAddress } from "@/utils";
 import MintGroupsContent from "./MintGroupsContent";
 import NoGroups from "./NoGroups";
+import CreateCollective from "./CreateCollective";
+import Messages from "./Messages";
+import ManageCollective from "./ManageCollective";
 
 const Mint: React.FC<RouteComponentProps> = ({ match }) => {
   const page = useRef(undefined);
@@ -31,6 +34,22 @@ const Mint: React.FC<RouteComponentProps> = ({ match }) => {
     <IonPage ref={page}>
       <Header title="Mint" />
       <IonContent className="ion-padding" color="light">
+        <IonRouterOutlet className="app-page-router-outlet">
+          <Route
+            path={`/mint/createCollective`}
+            component={CreateCollective}
+            exact
+          />
+          <Route
+            path={`/mint/manageCollective`}
+            component={ManageCollective}
+            exact
+          />
+
+          <Route exact path="/discover">
+            <Redirect to="/discover/new" />
+          </Route>
+        </IonRouterOutlet>
         {myGroups && myGroups.length > 0 ? (
           <MintGroupsContent
             myGroups={myGroups}

--- a/frontend/src/pages/Mint/Mint.tsx
+++ b/frontend/src/pages/Mint/Mint.tsx
@@ -1,4 +1,3 @@
-import Header from "@/components/Header";
 import {
   IonContent,
   IonPage,
@@ -7,15 +6,14 @@ import {
 } from "@ionic/react";
 import { useEffect } from "react";
 import useGetMyGroups from "@/hooks/Groups/useGetMyGroups";
-
 import { Route, RouteComponentProps } from "react-router";
 import MintGroupsContent from "./MintGroupsContent";
 import NoGroups from "./NoGroups";
 import CreateCollective from "./CreateCollective";
-import Messages from "./Messages";
 import ManageCollective from "./ManageCollective";
 import { routes } from "@/utils/routeNames";
 import CollectiveInvites from "./CollectiveInvites";
+import { PageLoadingIndicator } from "@/components/PageLoadingIndicator";
 
 const Mint: React.FC<RouteComponentProps> = ({ match }) => {
   const { myGroups, loading, reload } = useGetMyGroups();
@@ -24,44 +22,50 @@ const Mint: React.FC<RouteComponentProps> = ({ match }) => {
   console.log(myGroups, "myg grouups");
 
   //TODO: make the logic for this more bug-proof
-  /*   useEffect(() => {
-    if (myGroups && myGroups.length > 0 && !loading) {
-      router.push(routes.mintPage.myCollectives);
-    } else {
-      router.push(routes.mintPage.noCollectives);
+  useEffect(() => {
+    if (!loading) {
+      if (myGroups && myGroups.length > 0) {
+        router.push(routes.mintPage.myCollectives);
+      } else if (myGroups && !myGroups.length) {
+        router.push(routes.mintPage.noCollectives);
+      }
     }
-  }, [myGroups]); */
+  }, [myGroups]);
 
   return (
     <IonPage>
       <IonContent className="ion-padding" color="light">
-        <IonRouterOutlet className="app-page-router-outlet">
-          <Route
-            path={routes.mintPage.createCollective}
-            component={CreateCollective}
-            exact
-          />
-          <Route
-            path={routes.mintPage.manageCollective}
-            component={ManageCollective}
-            exact
-          />
-          <Route
-            path={routes.mintPage.myCollectives}
-            component={MintGroupsContent}
-            exact
-          />
-          <Route
-            path={routes.mintPage.noCollectives}
-            component={NoGroups}
-            exact
-          />
-          <Route
-            path={routes.mintPage.collectiveInvites}
-            component={CollectiveInvites}
-            exact
-          />
-        </IonRouterOutlet>
+        {loading ? (
+          <PageLoadingIndicator />
+        ) : (
+          <IonRouterOutlet className="app-page-router-outlet">
+            <Route
+              path={routes.mintPage.createCollective}
+              component={CreateCollective}
+              exact
+            />
+            <Route
+              path={routes.mintPage.manageCollective}
+              component={ManageCollective}
+              exact
+            />
+            <Route
+              path={routes.mintPage.myCollectives}
+              component={MintGroupsContent}
+              exact
+            />
+            <Route
+              path={routes.mintPage.noCollectives}
+              component={NoGroups}
+              exact
+            />
+            <Route
+              path={routes.mintPage.collectiveInvites}
+              component={CollectiveInvites}
+              exact
+            />
+          </IonRouterOutlet>
+        )}
       </IonContent>
     </IonPage>
   );

--- a/frontend/src/pages/Mint/Mint.tsx
+++ b/frontend/src/pages/Mint/Mint.tsx
@@ -1,11 +1,14 @@
 import Header from "@/components/Header";
-import { IonButton, IonContent, IonPage, IonRouterOutlet } from "@ionic/react";
-import { useEffect, useRef, useState } from "react";
+import {
+  IonContent,
+  IonPage,
+  IonRouterOutlet,
+  useIonRouter,
+} from "@ionic/react";
+import { useEffect } from "react";
 import useGetMyGroups from "@/hooks/Groups/useGetMyGroups";
-import CreateGroupModal from "./CreateGroupModal";
-import { PageLoadingIndicator } from "@/components/PageLoadingIndicator";
-import { Redirect, Route, RouteComponentProps } from "react-router";
-import { shortenAddress } from "@/utils";
+
+import { Route, RouteComponentProps } from "react-router";
 import MintGroupsContent from "./MintGroupsContent";
 import NoGroups from "./NoGroups";
 import CreateCollective from "./CreateCollective";
@@ -13,26 +16,21 @@ import Messages from "./Messages";
 import ManageCollective from "./ManageCollective";
 
 const Mint: React.FC<RouteComponentProps> = ({ match }) => {
-  const page = useRef(undefined);
+  const { myGroups, loading, reload } = useGetMyGroups();
 
-  const [presentingElement, setPresentingElement] = useState<
-    HTMLElement | undefined
-  >(undefined);
-
-  const {
-    myGroups,
-    loading: loadingGroups,
-    reload: reloadGroups,
-  } = useGetMyGroups();
-  useEffect(() => {
-    setPresentingElement(page.current);
-  }, []);
-
+  const router = useIonRouter();
   console.log(myGroups, "myg grouups");
 
+  useEffect(() => {
+    if (myGroups && myGroups.length > 0) {
+      router.push("/mint/collectiveContent");
+    } else {
+      router.push("/mint/collectiveContent");
+    }
+  }, []);
+
   return (
-    <IonPage ref={page}>
-      <Header title="Mint" />
+    <IonPage>
       <IonContent className="ion-padding" color="light">
         <IonRouterOutlet className="app-page-router-outlet">
           <Route
@@ -45,21 +43,13 @@ const Mint: React.FC<RouteComponentProps> = ({ match }) => {
             component={ManageCollective}
             exact
           />
-
-          <Route exact path="/discover">
-            <Redirect to="/discover/new" />
-          </Route>
-        </IonRouterOutlet>
-        {myGroups && myGroups.length > 0 ? (
-          <MintGroupsContent
-            myGroups={myGroups}
-            loadingGroups={loadingGroups}
-            reloadGroups={reloadGroups}
-            match={match}
+          <Route
+            path={`/mint/collectiveContent`}
+            component={MintGroupsContent}
+            exact
           />
-        ) : (
-          <NoGroups />
-        )}
+          <Route path={`/mint/noCollectives`} component={NoGroups} exact />
+        </IonRouterOutlet>
       </IonContent>
     </IonPage>
   );

--- a/frontend/src/pages/Mint/Mint.tsx
+++ b/frontend/src/pages/Mint/Mint.tsx
@@ -14,6 +14,8 @@ import NoGroups from "./NoGroups";
 import CreateCollective from "./CreateCollective";
 import Messages from "./Messages";
 import ManageCollective from "./ManageCollective";
+import { routes } from "@/utils/routeNames";
+import CollectiveInvites from "./CollectiveInvites";
 
 const Mint: React.FC<RouteComponentProps> = ({ match }) => {
   const { myGroups, loading, reload } = useGetMyGroups();
@@ -21,34 +23,44 @@ const Mint: React.FC<RouteComponentProps> = ({ match }) => {
   const router = useIonRouter();
   console.log(myGroups, "myg grouups");
 
-  useEffect(() => {
-    if (myGroups && myGroups.length > 0) {
-      router.push("/mint/collectiveContent");
+  //TODO: make the logic for this more bug-proof
+  /*   useEffect(() => {
+    if (myGroups && myGroups.length > 0 && !loading) {
+      router.push(routes.mintPage.myCollectives);
     } else {
-      router.push("/mint/collectiveContent");
+      router.push(routes.mintPage.noCollectives);
     }
-  }, []);
+  }, [myGroups]); */
 
   return (
     <IonPage>
       <IonContent className="ion-padding" color="light">
         <IonRouterOutlet className="app-page-router-outlet">
           <Route
-            path={`/mint/createCollective`}
+            path={routes.mintPage.createCollective}
             component={CreateCollective}
             exact
           />
           <Route
-            path={`/mint/manageCollective`}
+            path={routes.mintPage.manageCollective}
             component={ManageCollective}
             exact
           />
           <Route
-            path={`/mint/collectiveContent`}
+            path={routes.mintPage.myCollectives}
             component={MintGroupsContent}
             exact
           />
-          <Route path={`/mint/noCollectives`} component={NoGroups} exact />
+          <Route
+            path={routes.mintPage.noCollectives}
+            component={NoGroups}
+            exact
+          />
+          <Route
+            path={routes.mintPage.collectiveInvites}
+            component={CollectiveInvites}
+            exact
+          />
         </IonRouterOutlet>
       </IonContent>
     </IonPage>

--- a/frontend/src/pages/Mint/MintGroupsContent.tsx
+++ b/frontend/src/pages/Mint/MintGroupsContent.tsx
@@ -13,6 +13,7 @@ import {
   IonListHeader,
   IonNote,
   IonButton,
+  useIonRouter,
 } from "@ionic/react";
 
 import CreateGroupModal from "./CreateGroupModal";
@@ -33,13 +34,12 @@ const MintGroupsContent = ({
   loadingGroups,
   match,
 }: MintGroupsContentProps) => {
-  const createGroupModal = useRef<HTMLIonModalElement>(null);
-  const createPoolModal = useRef<HTMLIonModalElement>(null);
+  const router = useIonRouter();
 
-  function handleCreateGroup(groupId: number) {
-    reloadGroups();
-    // router.push(`messages/${groupId}`);
-  }
+  const handleNavigateToCreateCollective = () => {
+    router.push("/mint/createCollective");
+  };
+
   return (
     <IonContent>
       {loadingGroups ? (
@@ -78,17 +78,12 @@ const MintGroupsContent = ({
             : null}
         </IonList>
       )}
-      {/* TODO: make this a page that is routed to, not a modal */}
-      <CreateGroupModal
-        trigger="open-create-group-modal"
-        ref={createGroupModal}
-        onSuccess={handleCreateGroup}
-      />
 
       <IonFab slot="fixed" vertical="bottom" horizontal="end">
         <IonFabButton
           id="open-create-group-modal"
           className="create-fab-button"
+          onClick={handleNavigateToCreateCollective}
         >
           <IonIcon src="/assets/icons/pencil.svg"></IonIcon>
           <IonLabel>Create Group</IonLabel>

--- a/frontend/src/pages/Mint/MintGroupsContent.tsx
+++ b/frontend/src/pages/Mint/MintGroupsContent.tsx
@@ -19,13 +19,14 @@ import { RouteComponentProps } from "react-router";
 import Header from "@/components/Header";
 import useGetMyGroups from "@/hooks/Groups/useGetMyGroups";
 import MintTopBar from "@/components/Mint/MintTopBar";
+import { routes } from "@/utils/routeNames";
 
 const MintGroupsContent: React.FC<RouteComponentProps> = ({ match }) => {
   const { myGroups, loading } = useGetMyGroups();
   const router = useIonRouter();
 
   const handleNavigateToCreateCollective = () => {
-    router.push("/mint/createCollective");
+    router.push(routes.mintPage.createCollective);
   };
 
   return (

--- a/frontend/src/pages/Mint/MintGroupsContent.tsx
+++ b/frontend/src/pages/Mint/MintGroupsContent.tsx
@@ -18,6 +18,7 @@ import { shortenAddress } from "@/utils";
 import { RouteComponentProps } from "react-router";
 import Header from "@/components/Header";
 import useGetMyGroups from "@/hooks/Groups/useGetMyGroups";
+import MintTopBar from "@/components/Mint/MintTopBar";
 
 const MintGroupsContent: React.FC<RouteComponentProps> = ({ match }) => {
   const { myGroups, loading } = useGetMyGroups();
@@ -30,14 +31,13 @@ const MintGroupsContent: React.FC<RouteComponentProps> = ({ match }) => {
   return (
     <IonPage>
       <Header title="Mint" />
-      <IonContent>
+
+      <IonContent className="ion-padding">
+        <MintTopBar />
         {loading ? (
           <PageLoadingIndicator />
         ) : (
           <IonList inset={true}>
-            <IonListHeader>
-              <IonLabel>My Groups</IonLabel>
-            </IonListHeader>
             {myGroups
               ? myGroups.map((group: any, index: number) => (
                   <IonItem

--- a/frontend/src/pages/Mint/MintGroupsContent.tsx
+++ b/frontend/src/pages/Mint/MintGroupsContent.tsx
@@ -1,39 +1,26 @@
 import { PageLoadingIndicator } from "@/components/PageLoadingIndicator";
 import {
-  IonContent,
   IonPage,
   IonFab,
   IonFabButton,
   IonIcon,
-  IonFabList,
   IonAvatar,
   IonItem,
   IonLabel,
   IonList,
   IonListHeader,
   IonNote,
-  IonButton,
   useIonRouter,
+  IonContent,
 } from "@ionic/react";
-
-import CreateGroupModal from "./CreateGroupModal";
 import { shortenAddress } from "@/utils";
-import { useRef } from "react";
-import { Group } from "@/types/chat";
-import { RouteComponentProps } from "react-router";
-export interface MintGroupsContentProps {
-  myGroups: Group[];
-  loadingGroups: boolean;
-  reloadGroups: () => void;
-  match: any;
-}
 
-const MintGroupsContent = ({
-  myGroups,
-  reloadGroups,
-  loadingGroups,
-  match,
-}: MintGroupsContentProps) => {
+import { RouteComponentProps } from "react-router";
+import Header from "@/components/Header";
+import useGetMyGroups from "@/hooks/Groups/useGetMyGroups";
+
+const MintGroupsContent: React.FC<RouteComponentProps> = ({ match }) => {
+  const { myGroups, loading } = useGetMyGroups();
   const router = useIonRouter();
 
   const handleNavigateToCreateCollective = () => {
@@ -41,55 +28,58 @@ const MintGroupsContent = ({
   };
 
   return (
-    <IonContent>
-      {loadingGroups ? (
-        <PageLoadingIndicator />
-      ) : (
-        <IonList inset={true}>
-          <IonListHeader>
-            <IonLabel>My Groups</IonLabel>
-          </IonListHeader>
-          {myGroups
-            ? myGroups.map((group: any, index: number) => (
-                <IonItem
-                  button
-                  href={`${match.url}/${group.id}/challenges`}
-                  key={index}
-                  detail={true}
-                >
-                  <IonAvatar aria-hidden="true" slot="start">
-                    <img
-                      alt=""
-                      src="https://ionicframework.com/docs/img/demos/avatar.svg"
-                    />
-                  </IonAvatar>
-                  <IonLabel>
-                    <h3>
-                      {group.name}
-                      {group.id}
-                    </h3>
-                    <p>Members: {group.members}</p>
-                  </IonLabel>
-                  <IonNote color="medium" slot="end">
-                    {shortenAddress(group.publicAddress)}
-                  </IonNote>
-                </IonItem>
-              ))
-            : null}
-        </IonList>
-      )}
+    <IonPage>
+      <Header title="Mint" />
+      <IonContent>
+        {loading ? (
+          <PageLoadingIndicator />
+        ) : (
+          <IonList inset={true}>
+            <IonListHeader>
+              <IonLabel>My Groups</IonLabel>
+            </IonListHeader>
+            {myGroups
+              ? myGroups.map((group: any, index: number) => (
+                  <IonItem
+                    button
+                    href={`${match.url}/${group.id}/challenges`}
+                    key={index}
+                    detail={true}
+                  >
+                    <IonAvatar aria-hidden="true" slot="start">
+                      <img
+                        alt=""
+                        src="https://ionicframework.com/docs/img/demos/avatar.svg"
+                      />
+                    </IonAvatar>
+                    <IonLabel>
+                      <h3>
+                        {group.name}
+                        {group.id}
+                      </h3>
+                      <p>Members: {group.members}</p>
+                    </IonLabel>
+                    <IonNote color="medium" slot="end">
+                      {shortenAddress(group.publicAddress)}
+                    </IonNote>
+                  </IonItem>
+                ))
+              : null}
+          </IonList>
+        )}
 
-      <IonFab slot="fixed" vertical="bottom" horizontal="end">
-        <IonFabButton
-          id="open-create-group-modal"
-          className="create-fab-button"
-          onClick={handleNavigateToCreateCollective}
-        >
-          <IonIcon src="/assets/icons/pencil.svg"></IonIcon>
-          <IonLabel>Create Group</IonLabel>
-        </IonFabButton>
-      </IonFab>
-    </IonContent>
+        <IonFab slot="fixed" vertical="bottom" horizontal="end">
+          <IonFabButton
+            id="open-create-group-modal"
+            className="create-fab-button"
+            onClick={handleNavigateToCreateCollective}
+          >
+            <IonIcon src="/assets/icons/pencil.svg"></IonIcon>
+            <IonLabel>Create Group</IonLabel>
+          </IonFabButton>
+        </IonFab>
+      </IonContent>
+    </IonPage>
   );
 };
 

--- a/frontend/src/pages/Mint/NoGroups.tsx
+++ b/frontend/src/pages/Mint/NoGroups.tsx
@@ -1,21 +1,17 @@
+import Header from "@/components/Header";
 import useGetMyGroups from "@/hooks/Groups/useGetMyGroups";
 import { IonButton, IonContent, IonItem, IonPage } from "@ionic/react";
 import { useWeb3Modal } from "@web3modal/wagmi/react";
 import { useEffect } from "react";
+import { RouteComponentProps } from "react-router";
 import { useAccount } from "wagmi";
 
 export interface NoGroupsProps {}
 
-const NoGroups = ({}: NoGroupsProps) => {
+const NoGroups: React.FC<RouteComponentProps> = ({ match }) => {
   const { address, isConnected } = useAccount();
   const { open } = useWeb3Modal();
   const { fetchUserGroups } = useGetMyGroups();
-
-  useEffect(() => {
-    if (isConnected) {
-      fetchUserGroups();
-    }
-  }, [isConnected]);
 
   const handleCreateCollective = async () => {
     //TODO: handle routing and
@@ -27,7 +23,8 @@ const NoGroups = ({}: NoGroupsProps) => {
   };
 
   return (
-    <IonContent>
+    <IonPage>
+      <Header title="Mint" />
       <div className="purple-container">
         <p className="purple-container-text mb-1">
           To find previous collected content and Collective connect the same
@@ -42,7 +39,7 @@ const NoGroups = ({}: NoGroupsProps) => {
           {address ? "Create Collective" : "Connect"}
         </IonButton>
       </div>
-    </IonContent>
+    </IonPage>
   );
 };
 

--- a/frontend/src/pages/Mint/NoGroups.tsx
+++ b/frontend/src/pages/Mint/NoGroups.tsx
@@ -1,14 +1,29 @@
+import useGetMyGroups from "@/hooks/Groups/useGetMyGroups";
 import { IonButton, IonContent, IonItem, IonPage } from "@ionic/react";
+import { useWeb3Modal } from "@web3modal/wagmi/react";
+import { useEffect } from "react";
 import { useAccount } from "wagmi";
 
 export interface NoGroupsProps {}
 
 const NoGroups = ({}: NoGroupsProps) => {
-  const { address } = useAccount();
+  const { address, isConnected } = useAccount();
+  const { open } = useWeb3Modal();
+  const { fetchUserGroups } = useGetMyGroups();
 
-  const handleCreateCollective = () => {
-    //TODO: handle routing and/or connect wallet here
-    //route.push(/createCollective)
+  useEffect(() => {
+    if (isConnected) {
+      fetchUserGroups();
+    }
+  }, [isConnected]);
+
+  const handleCreateCollective = async () => {
+    //TODO: handle routing and
+    if (address) {
+      //route.push(/createCollective)
+    } else {
+      await open();
+    }
   };
 
   return (

--- a/frontend/src/pages/Mint/NoGroups.tsx
+++ b/frontend/src/pages/Mint/NoGroups.tsx
@@ -25,20 +25,22 @@ const NoGroups: React.FC<RouteComponentProps> = ({ match }) => {
   return (
     <IonPage>
       <Header title="Mint" />
-      <div className="purple-container">
-        <p className="purple-container-text mb-1">
-          To find previous collected content and Collective connect the same
-          wallet.
-        </p>
-        <br></br>
-        <IonButton
-          onClick={handleCreateCollective}
-          shape="round"
-          color="primary"
-        >
-          {address ? "Create Collective" : "Connect"}
-        </IonButton>
-      </div>
+      <IonContent className="ion-padding">
+        <div className="purple-container">
+          <p className="purple-container-text mb-1">
+            To find previous collected content and Collective connect the same
+            wallet.
+          </p>
+          <br></br>
+          <IonButton
+            onClick={handleCreateCollective}
+            shape="round"
+            color="primary"
+          >
+            {address ? "Create Collective" : "Connect"}
+          </IonButton>
+        </div>
+      </IonContent>
     </IonPage>
   );
 };

--- a/frontend/src/theme/main.css
+++ b/frontend/src/theme/main.css
@@ -342,7 +342,7 @@ ion-toolbar {
   align-items: center;
   justify-content: center;
   background-color: var(--light-purple-background);
-  width: 90%;
+  width: 95%;
   height: 40%;
   margin: 0 auto;
   border-radius: 20px;

--- a/frontend/src/utils/routeNames.ts
+++ b/frontend/src/utils/routeNames.ts
@@ -1,0 +1,9 @@
+export const routes = {
+    mintPage: {
+        myCollectives: "/mint/collectiveContent",
+        manageCollective: "/mint/manageCollective",
+        createCollective: "/mint/createCollective",
+        noCollectives: "/mint/noCollectives",
+        collectiveInvites: "/mint/collectiveInvites"
+    }
+}


### PR DESCRIPTION
- Added all (or most) mint routes
- Added static route variables to make it easier to remember, maintain, change and avoid typos
- Refactored the 'Create Collective' into a page instead of a modal
- Added the top bar for the mint section, now you can tab between 'collectives vs invites'
